### PR TITLE
CA-71 add shutter blur to random scene and fix compilation unchanged fixes

### DIFF
--- a/camera.h
+++ b/camera.h
@@ -14,8 +14,8 @@ class camera {
             double aspect_ratio,
             double aperture,
             double focus_dist,
-            double _shutter0 = 0,
-            double _shutter1 = 1) {
+            double _time0 = 0,
+            double _time1 = 1) {
             
             auto theta = degrees_to_radians(vfov);
             auto h = tan(theta/2);
@@ -32,8 +32,8 @@ class camera {
             lower_left_corner = origin - horizontal/2 - vertical/2 - focus_dist*w;
 
             lens_radius = aperture / 2;
-            shutter0 = _shutter0;
-            shutter1 = _shutter1;
+            time0 = _time0;
+            time1 = _time1;
         }
 
         ray get_ray(double s, double t) const {
@@ -43,7 +43,7 @@ class camera {
 
             return ray(origin + offset, 
                 lower_left_corner + s*horizontal + t*vertical - origin - offset,
-                random_double(shutter0,shutter1));
+                random_double(time0,time1));
         }
     private:
         point3 origin;

--- a/main.cc
+++ b/main.cc
@@ -20,13 +20,27 @@
 #include <vector>
 #include <thread>
 
-/*
+
 hittable_list random_scene() {
 
     hittable_list world;
 
+    auto create_still_timeline = [](vec3 pos) -> std::shared_ptr<timeline> {
+        TimePosition tp1{0.0, pos, 0};
+        TimePosition tp2{1.0, pos, 0};
+        std::vector<TimePosition> time_positions{tp1, tp2};
+        return std::make_shared<timeline>(time_positions);
+    };
+
+    auto create_random_timeline = [](vec3 pos) -> std::shared_ptr<timeline> {
+        double y_end = random_double(pos.y(), pos.y() + 0.5);  // Adjust range as needed
+        TimePosition tp1{0.0, pos, 0};
+        TimePosition tp2{1.0, vec3(pos.x(), y_end, pos.z()), 0};
+        std::vector<TimePosition> time_positions{tp1, tp2};
+        return std::make_shared<timeline>(time_positions);
+    };
     auto ground_material = make_shared<lambertian>(color(0.5, 0.5, 0.5));
-    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, ground_material));
+    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, ground_material, create_still_timeline(point3(0,-1000,0))));
 
     for (int a = -11; a < 11; a++) {
 
@@ -41,7 +55,7 @@ hittable_list random_scene() {
                 if (choose_mat < 0.8) {
                     auto albedo = color::random() * color::random();
                     sphere_material = make_shared<lambertian>(albedo);
-                    world.add(make_shared<sphere>(center, 0.2, sphere_material));
+                    world.add(make_shared<sphere>(center, 0.2, sphere_material, create_random_timeline(center)));
                 } 
 
                 // metal
@@ -49,38 +63,32 @@ hittable_list random_scene() {
                     auto albedo = color::random(0.5, 1);
                     auto fuzz = random_double(0, 0.5);
                     sphere_material = make_shared<metal>(albedo, fuzz);
-                    world.add(make_shared<sphere>(center, 0.2, sphere_material));
+                    world.add(make_shared<sphere>(center, 0.2, sphere_material, create_random_timeline(center)));
                 } 
 
                 // glass
                 else {
                     sphere_material = make_shared<dielectric>(1.5);
-                    world.add(make_shared<sphere>(center, 0.2, sphere_material));
+                    world.add(make_shared<sphere>(center, 0.2, sphere_material, create_random_timeline(center)));
                 }
             }
         }
     }
 
-    TimePosition tp1{0.0, vec3(0, 1, 0), 0};
-    TimePosition tp2{1.0, vec3(0, 5, 0), 0};
-    std::vector<TimePosition> time_positions;
-    time_positions.push_back(tp1);
-    time_positions.push_back(tp2);
-    auto timeline_ptr = std::make_shared<timeline>(time_positions);
-
     auto material1 = make_shared<dielectric>(1.5);
-    world.add(make_shared<sphere>(point3(0, 1, 0), 1.0, material1));
+    world.add(make_shared<sphere>(point3(0, 1, 0), 1.0, material1, create_still_timeline(point3(0,1,0))));
 
     auto material2 = make_shared<lambertian>(color(0.4, 0.2, 0.1));
-    world.add(make_shared<sphere>(point3(-4, 1, 0), 1.0, material2));
+    world.add(make_shared<sphere>(point3(-4, 1, 0), 1.0, material2, create_still_timeline(point3(-4,1,0))));
 
     auto material3 = make_shared<metal>(color(0.7, 0.6, 0.5), 0.0);
-    world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3));
+    world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3, create_still_timeline(point3(4,1,0))));
 
     return world;
 }
-*/
 
+// castRay takes in an RTCScene, origin coordinates and direction coordinates of ray and casts it.
+// Returns any found intersections.
 bool castRay(RTCScene scene, 
              float ox, float oy, float oz,
              float dx, float dy, float dz) {
@@ -206,17 +214,20 @@ void render_scanlines(int lines, int start_line, RenderData& data, camera cam) {
 }
 
 int main() {
+    /*
+    // CAST RAY TEST
     RTCDevice device = initializeDevice();
     RTCScene scene = initializeScene(device);
 
-    /* This will hit the triangle at t=1. */
+    // This will hit the triangle at t=1.
     castRay(scene, 0.33f, 0.33f, -1, 0, 0, 1);
 
-    /* This will not hit anything. */
+    // This will not hit anything.
     castRay(scene, 1.00f, 1.00f, -1, 0, 0, 1);
 
     rtcReleaseScene(scene);
     rtcReleaseDevice(device);
+    */
     
     RenderData render_data; 
 
@@ -225,8 +236,6 @@ int main() {
     const int image_height = static_cast<int>(image_width / aspect_ratio);
     const int samples_per_pixel = 100;
     const int max_depth = 50;
-    
-    auto world = test_shutter_scene();
 
     render_data.image_width = image_width;
     render_data.image_height = image_height;
@@ -235,6 +244,7 @@ int main() {
     render_data.buffer = std::vector<color>(image_width * image_height);
     
     // Set World
+    // auto world = test_shutter_scene();
     auto world = random_scene();
     render_data.scene = world;
 

--- a/material.h
+++ b/material.h
@@ -69,7 +69,7 @@ class metal : public material {
 
         virtual bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered) const override {
 
-            vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+            vec3 reflected = reflect(r_in.direction().unit_vector(), rec.normal);
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
             attenuation = albedo;
 


### PR DESCRIPTION
A previous merge was not done correctly and thus compilation on test is coming up with errors.
`random_scene` never uses shutter blur capabilities - so added it.