### PR TITLE
CA-54 Embreeify Scene Construction

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -156,7 +156,7 @@ color ray_color(const ray& r, const hittable& world, int depth) {
     if (depth <= 0) {
         return color(0,0,0);
     }
-    
+
     // 0.001 instead of 0 to correct for shadow acne
     if (world.hit(r, 0.001, infinity, rec)) {
         ray scattered;
@@ -214,28 +214,13 @@ void render_scanlines(int lines, int start_line, RenderData& data, camera cam) {
 }
 
 int main() {
-    /*
-    // CAST RAY TEST
-    RTCDevice device = initializeDevice();
-    RTCScene scene = initializeScene(device);
-
-    // This will hit the triangle at t=1.
-    castRay(scene, 0.33f, 0.33f, -1, 0, 0, 1);
-
-    // This will not hit anything.
-    castRay(scene, 1.00f, 1.00f, -1, 0, 0, 1);
-
-    rtcReleaseScene(scene);
-    rtcReleaseDevice(device);
-    */
-    
     RenderData render_data; 
 
     const auto aspect_ratio = 3.0 / 2.0;
     const int image_width = 1200;
     const int image_height = static_cast<int>(image_width / aspect_ratio);
-    const int samples_per_pixel = 100;
-    const int max_depth = 50;
+    const int samples_per_pixel = 10;
+    const int max_depth = 10;
 
     render_data.image_width = image_width;
     render_data.image_height = image_height;
@@ -257,8 +242,12 @@ int main() {
 
     camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus, 0.0, 1.0);
 
+    // Simple usage of creating a CaitScene
+    RTCDevice device = initializeDevice();
+    CaitScene cs = CaitScene(device, cam);
+    rtcReleaseDevice(device);
 
-    // Start Render Timer
+    // Start Render Timer 
     auto start_time = std::chrono::high_resolution_clock::now();
 
     // Threading approach? : Divide the scanlines into N blocks

--- a/material.h
+++ b/material.h
@@ -2,7 +2,7 @@
 #define MATERIAL_H
 
 #include "general.h"
-//#include "hittable.h" // not sure if this should be here? might be a more elegant way
+#include "hittable.h"
 
 class hit_record;
 

--- a/scene.cc
+++ b/scene.cc
@@ -1,8 +1,35 @@
 #include "scene.h"
 #include <embree4/rtcore.h>
 
-RTCScene initializeScene(RTCDevice device) {
-    RTCScene scene = rtcNewScene(device);
+CaitScene::CaitScene(RTCDevice device, camera cam) : cam{cam}, rtc_scene{rtcNewScene(device)} {}
+
+CaitScene::~CaitScene() {
+    if (rtc_scene) {
+        rtcReleaseScene(rtc_scene);
+    }
+}
+
+void CaitScene::commitScene() { rtcCommitScene(rtc_scene); }
+
+void add_sphere(RTCDevice device, RTCScene scene) {
+    
+    RTCGeometry sphere = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_SPHERE_POINT);
+    float* spherev = (float*)rtcSetNewGeometryBuffer(sphere, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT4, 4*sizeof(float), 1);
+    if (spherev) {
+        spherev[0] = 0;
+        spherev[1] = 0;
+        spherev[2] = -1;
+        spherev[3] = 0.5;
+    }
+
+    rtcCommitGeometry(sphere);
+    unsigned int sphereID = rtcAttachGeometry(scene, sphere);
+    rtcReleaseGeometry(sphere);
+}
+
+void add_triangle(RTCDevice device, RTCScene scene) {
+    // moved code from main here to clean it up. this will be
+    // updated but just leaving to save the code.
     RTCGeometry geom = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_TRIANGLE);
     float* vertices = (float*) rtcSetNewGeometryBuffer(geom,
                                                      RTC_BUFFER_TYPE_VERTEX,
@@ -36,26 +63,4 @@ RTCScene initializeScene(RTCDevice device) {
     rtcCommitGeometry(geom);
     unsigned int triangleID = rtcAttachGeometry(scene, geom);
     rtcReleaseGeometry(geom);
-
-    rtcCommitScene(scene);
-
-    return scene;
 }
-
-void add_sphere(RTCDevice device, RTCScene scene) {
-    
-    RTCGeometry sphere = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_SPHERE_POINT);
-    float* spherev = (float*)rtcSetNewGeometryBuffer(sphere, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT4, 4*sizeof(float), 1);
-    if (spherev) {
-        spherev[0] = 0;
-        spherev[1] = 0;
-        spherev[2] = -1;
-        spherev[3] = 0.5;
-    }
-
-    rtcCommitGeometry(sphere);
-    unsigned int sphereID = rtcAttachGeometry(scene, sphere);
-    rtcReleaseGeometry(sphere);
-}
-
-// add_sphere(scene,sphere_width,.....)

--- a/scene.h
+++ b/scene.h
@@ -2,9 +2,41 @@
 #define SCENE_H
 
 #include <embree4/rtcore.h>
+#include <map>
+#include "camera.h"
+#include "material.h"
+#include "general.h"
 
-RTCScene initializeScene(RTCDevice device);
+// SCENE INTERFACE
+// The scene class object covers all relevant objects in a scene:
+// => Camera
+// => Meshes
+// => Lights
+
+// RAYTRACING
+// => When a ray is cast on a scene, rtcIntersect1 returns a geomID.
+// => When objects are added, their geomIDs are mapped to a material.
+// => Thus, a geomID tells renderer how to scatter the ray.
+
+// METHODS
+// => CaitScene can have emissives and meshes added to it.
+// => Once everything is added, the user commits the scene.
+
+class CaitScene {
+    public:
+    camera cam;
+    std::map<unsigned int, std::shared_ptr<material>> mat_map;
+    RTCScene rtc_scene;
+
+    // Default Constructor
+    // requires a device to initialize RTCScene
+    CaitScene(RTCDevice device, camera cam);
+    ~CaitScene();
+    void commitScene();
+};
 
 void add_sphere(RTCDevice device, RTCScene scene);
+void add_triangle(RTCDevice device, RTCScene scene);
 
-#endif 
+
+#endif


### PR DESCRIPTION
# Description
This introduces a new class to represent scenes - the CaitScene object. As of writing there is no implementation for a lot of embree meshes and stuff like that, so CaitScene is just a flexible skeleton for future expansion if needed:
- Camera
- Map to Materials
- RTCScene

See documentation in `scene.h` for explanation.
Docker Version: `base/bundle-v0.2.0`

## Tests
Tested shutter scene. 
Produced image in ~108 seconds, 10 samples and 10 depth.
Tested simple CaitScene initialization in `main` - runs and compiles. Hard to really do any other unit tests for it.

## Related Issues and Screenshots
![image](https://github.com/cypraeno/caitlyn/assets/25397938/c35f1107-f523-46a2-bcaa-9a98623e6b38)

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.