### PR TITLE
CA-54 Embreeify Scene Construction

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,9 @@
 FROM gcc:latest
 
-# docker build -f Dockerfile.bundled -t connortbot/caitlyn-mcrt:base .
+# cypraeno base development image
+# VERSION: v0.2.1
+
+# docker build -f Dockerfile.base -t connortbot/caitlyn-mcrt:base .
 # docker tag caitlyn-mcrt connortbot/caitlyn-mcrt
 # docker push connortbot/caitlyn-mcrt
 
@@ -8,7 +11,7 @@ FROM gcc:latest
 
 # Install required packages
 RUN apt-get update && \
-    apt-get install -y curl zip unzip tar git wget
+    apt-get install -y curl zip unzip tar git wget valgrind
 
 # Install CMake
 ARG CMAKE_VERSION=3.26.0
@@ -24,5 +27,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cm
 # -rf : r recursive f force
 # -xzvf : x extract -z gunzip (compress as extracting) -v verbose (list out extracts) -f file (follow cmake instructions)
 # bootstrap : make ready for compilation
+
+# Install Embree
+ARG EMBREE_VERSION=4.3.0
+ADD https://github.com/embree/embree/releases/download/v${EMBREE_VERSION}/embree-${EMBREE_VERSION}.x86_64.linux.tar.gz /opt
+RUN cd /opt && \
+    tar xzf embree-${EMBREE_VERSION}.x86_64.linux.tar.gz
+RUN echo "source embree-${EMBREE_VERSION}.x86_64.linux/embree-vars.sh" >> /root/.profile
 
 WORKDIR /app

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,11 +3,8 @@ FROM gcc:latest
 # cypraeno base development image
 # VERSION: v0.2.1
 
-# docker build -f Dockerfile.base -t connortbot/caitlyn-mcrt:base .
-# docker tag caitlyn-mcrt connortbot/caitlyn-mcrt
-# docker push connortbot/caitlyn-mcrt
-
-# This is a test to push to docker and github
+# docker build -f Dockerfile.base -t connortbot/caitlyn-mcrt:base-vX.X.X .
+# docker push connortbot/caitlyn-mcrt:base-vX.X.X
 
 # Install required packages
 RUN apt-get update && \

--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -1,10 +1,7 @@
 FROM gcc:latest
 
-# docker build -f Dockerfile.bundled -t connortbot/caitlyn-mcrt:base .
-# docker tag caitlyn-mcrt connortbot/caitlyn-mcrt
-# docker push connortbot/caitlyn-mcrt
-
-# This is a test to push to docker and github
+# docker build -f Dockerfile.bundled -t connortbot/caitlyn-mcrt:base-vX.X.X .
+# docker push connortbot/caitlyn-mcrt:base-vX.X.X
 
 # Install required packages
 RUN apt-get update && \

--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -25,5 +25,13 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cm
 # -xzvf : x extract -z gunzip (compress as extracting) -v verbose (list out extracts) -f file (follow cmake instructions)
 # bootstrap : make ready for compilation
 
+# Install Embree
+ARG EMBREE_VERSION=4.3.0
+ADD https://github.com/embree/embree/releases/download/v${EMBREE_VERSION}/embree-${EMBREE_VERSION}.x86_64.linux.tar.gz /opt
+RUN cd /opt && \
+    tar xzf embree-${EMBREE_VERSION}.x86_64.linux.tar.gz
+RUN echo "source embree-${EMBREE_VERSION}.x86_64.linux/embree-vars.sh" >> /root/.profile
+
+
 COPY . /app
 WORKDIR /app

--- a/camera.h
+++ b/camera.h
@@ -14,8 +14,8 @@ class camera {
             double aspect_ratio,
             double aperture,
             double focus_dist,
-            double _shutter0 = 0,
-            double _shutter1 = 1) {
+            double _time0 = 0,
+            double _time1 = 1) {
             
             auto theta = degrees_to_radians(vfov);
             auto h = tan(theta/2);
@@ -32,8 +32,8 @@ class camera {
             lower_left_corner = origin - horizontal/2 - vertical/2 - focus_dist*w;
 
             lens_radius = aperture / 2;
-            shutter0 = _shutter0;
-            shutter1 = _shutter1;
+            time0 = _time0;
+            time1 = _time1;
         }
 
         ray get_ray(double s, double t) const {
@@ -43,7 +43,7 @@ class camera {
 
             return ray(origin + offset, 
                 lower_left_corner + s*horizontal + t*vertical - origin - offset,
-                random_double(shutter0,shutter1));
+                random_double(time0,time1));
         }
     private:
         point3 origin;

--- a/main.cc
+++ b/main.cc
@@ -156,7 +156,7 @@ color ray_color(const ray& r, const hittable& world, int depth) {
     if (depth <= 0) {
         return color(0,0,0);
     }
-    
+
     // 0.001 instead of 0 to correct for shadow acne
     if (world.hit(r, 0.001, infinity, rec)) {
         ray scattered;
@@ -214,28 +214,13 @@ void render_scanlines(int lines, int start_line, RenderData& data, camera cam) {
 }
 
 int main() {
-    /*
-    // CAST RAY TEST
-    RTCDevice device = initializeDevice();
-    RTCScene scene = initializeScene(device);
-
-    // This will hit the triangle at t=1.
-    castRay(scene, 0.33f, 0.33f, -1, 0, 0, 1);
-
-    // This will not hit anything.
-    castRay(scene, 1.00f, 1.00f, -1, 0, 0, 1);
-
-    rtcReleaseScene(scene);
-    rtcReleaseDevice(device);
-    */
-    
     RenderData render_data; 
 
     const auto aspect_ratio = 3.0 / 2.0;
     const int image_width = 1200;
     const int image_height = static_cast<int>(image_width / aspect_ratio);
-    const int samples_per_pixel = 100;
-    const int max_depth = 50;
+    const int samples_per_pixel = 10;
+    const int max_depth = 10;
 
     render_data.image_width = image_width;
     render_data.image_height = image_height;
@@ -257,8 +242,12 @@ int main() {
 
     camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus, 0.0, 1.0);
 
+    // Simple usage of creating a CaitScene
+    RTCDevice device = initializeDevice();
+    CaitScene cs = CaitScene(device, cam);
+    rtcReleaseDevice(device);
 
-    // Start Render Timer
+    // Start Render Timer 
     auto start_time = std::chrono::high_resolution_clock::now();
 
     // Threading approach? : Divide the scanlines into N blocks

--- a/main.cc
+++ b/main.cc
@@ -20,13 +20,27 @@
 #include <vector>
 #include <thread>
 
-/*
+
 hittable_list random_scene() {
 
     hittable_list world;
 
+    auto create_still_timeline = [](vec3 pos) -> std::shared_ptr<timeline> {
+        TimePosition tp1{0.0, pos, 0};
+        TimePosition tp2{1.0, pos, 0};
+        std::vector<TimePosition> time_positions{tp1, tp2};
+        return std::make_shared<timeline>(time_positions);
+    };
+
+    auto create_random_timeline = [](vec3 pos) -> std::shared_ptr<timeline> {
+        double y_end = random_double(pos.y(), pos.y() + 0.5);  // Adjust range as needed
+        TimePosition tp1{0.0, pos, 0};
+        TimePosition tp2{1.0, vec3(pos.x(), y_end, pos.z()), 0};
+        std::vector<TimePosition> time_positions{tp1, tp2};
+        return std::make_shared<timeline>(time_positions);
+    };
     auto ground_material = make_shared<lambertian>(color(0.5, 0.5, 0.5));
-    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, ground_material));
+    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, ground_material, create_still_timeline(point3(0,-1000,0))));
 
     for (int a = -11; a < 11; a++) {
 
@@ -41,7 +55,7 @@ hittable_list random_scene() {
                 if (choose_mat < 0.8) {
                     auto albedo = color::random() * color::random();
                     sphere_material = make_shared<lambertian>(albedo);
-                    world.add(make_shared<sphere>(center, 0.2, sphere_material));
+                    world.add(make_shared<sphere>(center, 0.2, sphere_material, create_random_timeline(center)));
                 } 
 
                 // metal
@@ -49,38 +63,32 @@ hittable_list random_scene() {
                     auto albedo = color::random(0.5, 1);
                     auto fuzz = random_double(0, 0.5);
                     sphere_material = make_shared<metal>(albedo, fuzz);
-                    world.add(make_shared<sphere>(center, 0.2, sphere_material));
+                    world.add(make_shared<sphere>(center, 0.2, sphere_material, create_random_timeline(center)));
                 } 
 
                 // glass
                 else {
                     sphere_material = make_shared<dielectric>(1.5);
-                    world.add(make_shared<sphere>(center, 0.2, sphere_material));
+                    world.add(make_shared<sphere>(center, 0.2, sphere_material, create_random_timeline(center)));
                 }
             }
         }
     }
 
-    TimePosition tp1{0.0, vec3(0, 1, 0), 0};
-    TimePosition tp2{1.0, vec3(0, 5, 0), 0};
-    std::vector<TimePosition> time_positions;
-    time_positions.push_back(tp1);
-    time_positions.push_back(tp2);
-    auto timeline_ptr = std::make_shared<timeline>(time_positions);
-
     auto material1 = make_shared<dielectric>(1.5);
-    world.add(make_shared<sphere>(point3(0, 1, 0), 1.0, material1));
+    world.add(make_shared<sphere>(point3(0, 1, 0), 1.0, material1, create_still_timeline(point3(0,1,0))));
 
     auto material2 = make_shared<lambertian>(color(0.4, 0.2, 0.1));
-    world.add(make_shared<sphere>(point3(-4, 1, 0), 1.0, material2));
+    world.add(make_shared<sphere>(point3(-4, 1, 0), 1.0, material2, create_still_timeline(point3(-4,1,0))));
 
     auto material3 = make_shared<metal>(color(0.7, 0.6, 0.5), 0.0);
-    world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3));
+    world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3, create_still_timeline(point3(4,1,0))));
 
     return world;
 }
-*/
 
+// castRay takes in an RTCScene, origin coordinates and direction coordinates of ray and casts it.
+// Returns any found intersections.
 bool castRay(RTCScene scene, 
              float ox, float oy, float oz,
              float dx, float dy, float dz) {
@@ -206,17 +214,20 @@ void render_scanlines(int lines, int start_line, RenderData& data, camera cam) {
 }
 
 int main() {
+    /*
+    // CAST RAY TEST
     RTCDevice device = initializeDevice();
     RTCScene scene = initializeScene(device);
 
-    /* This will hit the triangle at t=1. */
+    // This will hit the triangle at t=1.
     castRay(scene, 0.33f, 0.33f, -1, 0, 0, 1);
 
-    /* This will not hit anything. */
+    // This will not hit anything.
     castRay(scene, 1.00f, 1.00f, -1, 0, 0, 1);
 
     rtcReleaseScene(scene);
     rtcReleaseDevice(device);
+    */
     
     RenderData render_data; 
 
@@ -225,8 +236,6 @@ int main() {
     const int image_height = static_cast<int>(image_width / aspect_ratio);
     const int samples_per_pixel = 100;
     const int max_depth = 50;
-    
-    auto world = test_shutter_scene();
 
     render_data.image_width = image_width;
     render_data.image_height = image_height;
@@ -235,6 +244,7 @@ int main() {
     render_data.buffer = std::vector<color>(image_width * image_height);
     
     // Set World
+    // auto world = test_shutter_scene();
     auto world = random_scene();
     render_data.scene = world;
 

--- a/material.h
+++ b/material.h
@@ -69,7 +69,7 @@ class metal : public material {
 
         virtual bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered) const override {
 
-            vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+            vec3 reflected = reflect(r_in.direction().unit_vector(), rec.normal);
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
             attenuation = albedo;
 

--- a/material.h
+++ b/material.h
@@ -2,7 +2,7 @@
 #define MATERIAL_H
 
 #include "general.h"
-//#include "hittable.h" // not sure if this should be here? might be a more elegant way
+#include "hittable.h"
 
 class hit_record;
 

--- a/scene.cc
+++ b/scene.cc
@@ -1,8 +1,35 @@
 #include "scene.h"
 #include <embree4/rtcore.h>
 
-RTCScene initializeScene(RTCDevice device) {
-    RTCScene scene = rtcNewScene(device);
+CaitScene::CaitScene(RTCDevice device, camera cam) : cam{cam}, rtc_scene{rtcNewScene(device)} {}
+
+CaitScene::~CaitScene() {
+    if (rtc_scene) {
+        rtcReleaseScene(rtc_scene);
+    }
+}
+
+void CaitScene::commitScene() { rtcCommitScene(rtc_scene); }
+
+void add_sphere(RTCDevice device, RTCScene scene) {
+    
+    RTCGeometry sphere = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_SPHERE_POINT);
+    float* spherev = (float*)rtcSetNewGeometryBuffer(sphere, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT4, 4*sizeof(float), 1);
+    if (spherev) {
+        spherev[0] = 0;
+        spherev[1] = 0;
+        spherev[2] = -1;
+        spherev[3] = 0.5;
+    }
+
+    rtcCommitGeometry(sphere);
+    unsigned int sphereID = rtcAttachGeometry(scene, sphere);
+    rtcReleaseGeometry(sphere);
+}
+
+void add_triangle(RTCDevice device, RTCScene scene) {
+    // moved code from main here to clean it up. this will be
+    // updated but just leaving to save the code.
     RTCGeometry geom = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_TRIANGLE);
     float* vertices = (float*) rtcSetNewGeometryBuffer(geom,
                                                      RTC_BUFFER_TYPE_VERTEX,
@@ -36,26 +63,4 @@ RTCScene initializeScene(RTCDevice device) {
     rtcCommitGeometry(geom);
     unsigned int triangleID = rtcAttachGeometry(scene, geom);
     rtcReleaseGeometry(geom);
-
-    rtcCommitScene(scene);
-
-    return scene;
 }
-
-void add_sphere(RTCDevice device, RTCScene scene) {
-    
-    RTCGeometry sphere = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_SPHERE_POINT);
-    float* spherev = (float*)rtcSetNewGeometryBuffer(sphere, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT4, 4*sizeof(float), 1);
-    if (spherev) {
-        spherev[0] = 0;
-        spherev[1] = 0;
-        spherev[2] = -1;
-        spherev[3] = 0.5;
-    }
-
-    rtcCommitGeometry(sphere);
-    unsigned int sphereID = rtcAttachGeometry(scene, sphere);
-    rtcReleaseGeometry(sphere);
-}
-
-// add_sphere(scene,sphere_width,.....)

--- a/scene.h
+++ b/scene.h
@@ -2,9 +2,41 @@
 #define SCENE_H
 
 #include <embree4/rtcore.h>
+#include <map>
+#include "camera.h"
+#include "material.h"
+#include "general.h"
 
-RTCScene initializeScene(RTCDevice device);
+// SCENE INTERFACE
+// The scene class object covers all relevant objects in a scene:
+// => Camera
+// => Meshes
+// => Lights
+
+// RAYTRACING
+// => When a ray is cast on a scene, rtcIntersect1 returns a geomID.
+// => When objects are added, their geomIDs are mapped to a material.
+// => Thus, a geomID tells renderer how to scatter the ray.
+
+// METHODS
+// => CaitScene can have emissives and meshes added to it.
+// => Once everything is added, the user commits the scene.
+
+class CaitScene {
+    public:
+    camera cam;
+    std::map<unsigned int, std::shared_ptr<material>> mat_map;
+    RTCScene rtc_scene;
+
+    // Default Constructor
+    // requires a device to initialize RTCScene
+    CaitScene(RTCDevice device, camera cam);
+    ~CaitScene();
+    void commitScene();
+};
 
 void add_sphere(RTCDevice device, RTCScene scene);
+void add_triangle(RTCDevice device, RTCScene scene);
 
-#endif 
+
+#endif


### PR DESCRIPTION
# Description
This introduces a new class to represent scenes - the CaitScene object. As of writing there is no implementation for a lot of embree meshes and stuff like that, so CaitScene is just a flexible skeleton for future expansion if needed:
- Camera
- Map to Materials
- RTCScene

See documentation in `scene.h` for explanation.
Docker Version: `base/bundle-v0.2.0`

## Tests
Tested shutter scene. 
Produced image in ~108 seconds, 10 samples and 10 depth.
Tested simple CaitScene initialization in `main` - runs and compiles. Hard to really do any other unit tests for it.

## Related Issues and Screenshots
![image](https://github.com/cypraeno/caitlyn/assets/25397938/c35f1107-f523-46a2-bcaa-9a98623e6b38)

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.