### PR TITLE
CA-58 Make rtcIntersectX interface

### DIFF
--- a/intersects.h
+++ b/intersects.h
@@ -16,3 +16,63 @@ void setupRayHit1(struct RTCRayHit& rayhit, const ray& r) {
     rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
     rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
 }
+
+/** @brief modifies given RTCRayHit object to be ready for rtcIntersect4 usage*/
+void setupRayHit4(struct RTCRayHit4& rayhit, std::vector<ray>& rays) {
+    int ix = 0;
+    for(auto r: rays) {
+        rayhit.ray.org_x[ix] = r.origin().x();
+        rayhit.ray.org_y[ix] = r.origin().y();
+        rayhit.ray.org_z[ix] = r.origin().z();
+        rayhit.ray.dir_x[ix] = r.direction().x();
+        rayhit.ray.dir_y[ix] = r.direction().y();
+        rayhit.ray.dir_z[ix] = r.direction().z();
+        rayhit.ray.tnear[ix] = 0.001;
+        rayhit.ray.tfar[ix] = std::numeric_limits<float>::infinity();
+        rayhit.ray.mask[ix] = -1;
+        rayhit.ray.flags[ix] = 0;
+        rayhit.hit.geomID[ix] = RTC_INVALID_GEOMETRY_ID;
+        rayhit.hit.instID[0][ix] = RTC_INVALID_GEOMETRY_ID;
+        ix += 1;
+    }
+}
+
+/** @brief modifies given RTCRayHit object to be ready for rtcIntersect8 usage*/
+void setupRayHit8(struct RTCRayHit8& rayhit, std::vector<ray>& rays) {
+    int ix = 0;
+    for(auto r: rays) {
+        rayhit.ray.org_x[ix] = r.origin().x();
+        rayhit.ray.org_y[ix] = r.origin().y();
+        rayhit.ray.org_z[ix] = r.origin().z();
+        rayhit.ray.dir_x[ix] = r.direction().x();
+        rayhit.ray.dir_y[ix] = r.direction().y();
+        rayhit.ray.dir_z[ix] = r.direction().z();
+        rayhit.ray.tnear[ix] = 0.001;
+        rayhit.ray.tfar[ix] = std::numeric_limits<float>::infinity();
+        rayhit.ray.mask[ix] = -1;
+        rayhit.ray.flags[ix] = 0;
+        rayhit.hit.geomID[ix] = RTC_INVALID_GEOMETRY_ID;
+        rayhit.hit.instID[0][ix] = RTC_INVALID_GEOMETRY_ID;
+        ix += 1;
+    }
+}
+
+/** @brief modifies given RTCRayHit object to be ready for rtcIntersect16 usage*/
+void setupRayHit4(struct RTCRayHit16& rayhit, std::vector<ray>& rays) {
+    int ix = 0;
+    for(auto r: rays) {
+        rayhit.ray.org_x[ix] = r.origin().x();
+        rayhit.ray.org_y[ix] = r.origin().y();
+        rayhit.ray.org_z[ix] = r.origin().z();
+        rayhit.ray.dir_x[ix] = r.direction().x();
+        rayhit.ray.dir_y[ix] = r.direction().y();
+        rayhit.ray.dir_z[ix] = r.direction().z();
+        rayhit.ray.tnear[ix] = 0.001;
+        rayhit.ray.tfar[ix] = std::numeric_limits<float>::infinity();
+        rayhit.ray.mask[ix] = -1;
+        rayhit.ray.flags[ix] = 0;
+        rayhit.hit.geomID[ix] = RTC_INVALID_GEOMETRY_ID;
+        rayhit.hit.instID[0][ix] = RTC_INVALID_GEOMETRY_ID;
+        ix += 1;
+    }
+}

--- a/intersects.h
+++ b/intersects.h
@@ -1,0 +1,18 @@
+// Semi-temporary helper header file for the rtcIntersectX functions.
+// Helpers do not actually fire the ray, they just set up the RTCRayHit objects with rays.
+
+/** @brief modifies given RTCRayHit object to be ready for rtcIntersect1 usage */
+void setupRayHit1(struct RTCRayHit& rayhit, const ray& r) {
+    rayhit.ray.org_x = r.origin().x();
+    rayhit.ray.org_y = r.origin().y();
+    rayhit.ray.org_z = r.origin().z();
+    rayhit.ray.dir_x = r.direction().x();
+    rayhit.ray.dir_y = r.direction().y();
+    rayhit.ray.dir_z = r.direction().z();
+    rayhit.ray.tnear = 0.001;
+    rayhit.ray.tfar = std::numeric_limits<float>::infinity();
+    rayhit.ray.mask = -1;
+    rayhit.ray.flags = 0;
+    rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
+    rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
+}

--- a/main.cc
+++ b/main.cc
@@ -8,6 +8,7 @@
 #include "vec3.h"
 #include "material.h"
 #include "sphere_primitive.h"
+#include "intersects.h"
 
 
 #include <iostream>
@@ -96,18 +97,7 @@ color colorize_ray(const ray& r, std::shared_ptr<Scene> scene, int depth) {
 
     // fire ray into scene and get ID.
     struct RTCRayHit rayhit;
-    rayhit.ray.org_x = r.origin().x();
-    rayhit.ray.org_y = r.origin().y();
-    rayhit.ray.org_z = r.origin().z();
-    rayhit.ray.dir_x = r.direction().x();
-    rayhit.ray.dir_y = r.direction().y();
-    rayhit.ray.dir_z = r.direction().z();
-    rayhit.ray.tnear = 0.001;
-    rayhit.ray.tfar = std::numeric_limits<float>::infinity();
-    rayhit.ray.mask = -1;
-    rayhit.ray.flags = 0;
-    rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
-    rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
+    setupRayHit1(rayhit, r);
 
     rtcIntersect1(scene->rtc_scene, &rayhit);
 


### PR DESCRIPTION
# Description
Added helpers in the newly added `intersects.h` to setup RTCRayHitX objects. They do NOT include setup of contexts (although I'm pretty sure the version of embree on 0.2.1 is updated that it auto chooses default).
Docker Version: `base-v0.2.1`

## Tests
Benchmark scene. Compiles as normal. No major changes.

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.