### PR TITLE
CA-100 Cutting render time using ray packets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,17 @@ TARGET_LINK_LIBRARIES(caitlyn embree)
 target_compile_features(caitlyn PUBLIC cxx_std_11) # Set the C++ standard to C++11
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2") # Set the optimization level to -O2
 
+# Set EMBREE_MAX_ISA based on compiler support
+if(COMPILER_SUPPORTS_AVX512)
+  target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=AVX512)
+elseif(COMPILER_SUPPORTS_AVX2)
+  target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=AVX2)
+elseif(COMPILER_SUPPORTS_AVX)
+  target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=AVX)
+elseif(COMPILER_SUPPORTS_SSE42)
+  target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=SSE4.2)
+endif()
+
 # Instructions
 # Create build files:
 # mkdir build (if it does not exist already)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.26) # Required
 project(Caitlyn VERSION 0.1.0) # Required
 set(CMAKE_BUILD_TYPE Debug)
 
+# Include SIMD Configuration
+include(${CMAKE_CURRENT_SOURCE_DIR}/SIMDConfig.cmake)
+
 # EMBREE CONFIG
 set(embree_DIR ../opt/lib/cmake/embree-4.3.0/)
 # set(TBB_DIR ../opt/lib/cmake/tbb/) haven't installed TBB, doesn't exist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,7 @@ target_compile_features(caitlyn PUBLIC cxx_std_11) # Set the C++ standard to C++
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2") # Set the optimization level to -O2
 
 # Set EMBREE_MAX_ISA based on compiler support
-if(COMPILER_SUPPORTS_AVX512)
-  target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=AVX512)
-elseif(COMPILER_SUPPORTS_AVX2)
+if(COMPILER_SUPPORTS_AVX2)
   target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=AVX2)
 elseif(COMPILER_SUPPORTS_AVX)
   target_compile_definitions(caitlyn PRIVATE EMBREE_MAX_ISA=AVX)

--- a/SIMDConfig.cmake
+++ b/SIMDConfig.cmake
@@ -1,10 +1,10 @@
 include(CheckCXXCompilerFlag)
 
 # Check and add support for various SIMD instructions
-check_cxx_compiler_flag("-mavx512f" COMPILER_SUPPORTS_AVX512)
-if(COMPILER_SUPPORTS_AVX512)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f")
-endif()
+#check_cxx_compiler_flag("-mavx512f" COMPILER_SUPPORTS_AVX512)
+#if(COMPILER_SUPPORTS_AVX512)
+#  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f")
+#endif()
 
 check_cxx_compiler_flag("-mavx2" COMPILER_SUPPORTS_AVX2)
 if(COMPILER_SUPPORTS_AVX2)

--- a/SIMDConfig.cmake
+++ b/SIMDConfig.cmake
@@ -1,0 +1,22 @@
+include(CheckCXXCompilerFlag)
+
+# Check and add support for various SIMD instructions
+check_cxx_compiler_flag("-mavx512f" COMPILER_SUPPORTS_AVX512)
+if(COMPILER_SUPPORTS_AVX512)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f")
+endif()
+
+check_cxx_compiler_flag("-mavx2" COMPILER_SUPPORTS_AVX2)
+if(COMPILER_SUPPORTS_AVX2)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+endif()
+
+check_cxx_compiler_flag("-mavx" COMPILER_SUPPORTS_AVX)
+if(COMPILER_SUPPORTS_AVX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+endif()
+
+check_cxx_compiler_flag("-msse4.2" COMPILER_SUPPORTS_SSE42)
+if(COMPILER_SUPPORTS_SSE42)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+endif()

--- a/intersects.h
+++ b/intersects.h
@@ -58,7 +58,7 @@ void setupRayHit8(struct RTCRayHit8& rayhit, std::vector<ray>& rays) {
 }
 
 /** @brief modifies given RTCRayHit object to be ready for rtcIntersect16 usage*/
-void setupRayHit4(struct RTCRayHit16& rayhit, std::vector<ray>& rays) {
+void setupRayHit16(struct RTCRayHit16& rayhit, std::vector<ray>& rays) {
     int ix = 0;
     for(auto r: rays) {
         rayhit.ray.org_x[ix] = r.origin().x();

--- a/main.cc
+++ b/main.cc
@@ -301,10 +301,10 @@ int main() {
     RenderData render_data; 
 
     const auto aspect_ratio = 3.0 / 2.0;
-    const int image_width = 420;
+    const int image_width = 1200;
     const int image_height = static_cast<int>(image_width / aspect_ratio);
-    const int samples_per_pixel = 2;
-    const int max_depth = 3;
+    const int samples_per_pixel = 50;
+    const int max_depth = 50;
 
     render_data.image_width = image_width;
     render_data.image_height = image_height;
@@ -333,10 +333,11 @@ int main() {
     // Start Render Timer 
     auto start_time = std::chrono::high_resolution_clock::now();
     render_data.completed_lines = 0;
-    render_scanlines_sse(image_height,image_height-1,cs,render_data,cam);
-    /*
+    //render_scanlines_sse(image_height,image_height-1,cs,render_data,cam);
+
     // Threading approach? : Divide the scanlines into N blocks
     const int num_threads = std::thread::hardware_concurrency() - 1;
+    std::cerr << num_threads << std::endl;
     // Image height is the number of scanlines, suppose image_height = 800
     const int lines_per_thread = image_height / num_threads;
     const int leftOver = image_height % num_threads;
@@ -358,7 +359,7 @@ int main() {
     }
     std::cerr << "Joining all threads" << std::endl;
     threads.clear();
-    */
+
     std::cout << "P3" << std::endl;
     std::cout << image_width << ' ' << image_height << std::endl;
     std::cout << 255 << std::endl;

--- a/main.cc
+++ b/main.cc
@@ -167,6 +167,12 @@ struct RayQueue {
     int depth;
     ray r;
 };
+
+/**
+ * @brief Calculates colours of the given RenderData's buffer according to the assigned lines of pixels.
+ * 
+ * @note is one of many planned functions supporting SSE, AVX, AVX512 i.e 4/8/16 packet size
+*/
 void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scene_ptr, RenderData& data, Camera cam) {
     int image_width         = data.image_width;
     int image_height        = data.image_height;

--- a/main.cc
+++ b/main.cc
@@ -176,6 +176,7 @@ void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scen
     for (int j=start_line; j>=start_line - (lines - 1); --j) {
         for (int s=0; s < samples_per_pixel; s++) {
             std::vector<RayQueue> queue;
+            std::vector<color> temp_buffer;
             std::vector<RayQueue> current(4); // size = 4 only
             for (int i=image_width-1; i>=0; --i) {
                 auto u = (i + random_double()) / (image_width-1);
@@ -195,7 +196,14 @@ void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scen
             }
 
             while (!queue.empty()) {
-                // start block rendering
+                setupRayHit4(rayhit, current);
+                rtcIntersect4(scene->rtc_scene, &rayhit);
+                
+                HitInfo record;
+
+                for (int i=0; i<4; i++) {
+                    // process each ray by editing the temp_buffer and updating current queue
+                }
             }
         }
     }

--- a/main.cc
+++ b/main.cc
@@ -162,6 +162,45 @@ void render_scanlines(int lines, int start_line, std::shared_ptr<Scene> scene_pt
     }
 }
 
+struct RayQueue {
+    int index;
+    int depth;
+    ray r;
+};
+void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scene_ptr, RenderData& data, Camera cam) {
+    int image_width         = data.image_width;
+    int image_height        = data.image_height;
+    int samples_per_pixel   = data.samples_per_pixel;
+    int max_depth           = data.max_depth;
+    
+    for (int j=start_line; j>=start_line - (lines - 1); --j) {
+        for (int s=0; s < samples_per_pixel; s++) {
+            std::vector<RayQueue> queue;
+            std::vector<RayQueue> current(4); // size = 4 only
+            for (int i=image_width-1; i>=0; --i) {
+                auto u = (i + random_double()) / (image_width-1);
+                auto v = (j + random_double()) / (image_height-1);
+                ray r = cam.get_ray(u, v);
+                
+                RayQueue q = { i, 0, r };
+                queue.push_back(q);
+            }
+
+            RTCRayHit4 rayhit;
+
+            for (int i=0; i<4; i++) {
+                RayQueue back = queue.back();
+                queue.pop_back();
+                current.push_back(back);
+            }
+
+            while (!queue.empty()) {
+                // start block rendering
+            }
+        }
+    }
+}
+
 int main() {
     RenderData render_data; 
 


### PR DESCRIPTION
# Description
Creating a new version of `render_scanlines` that implements ray packets using `rtcIntersectX`, which uses SIMD compatible architectures to process multiple rays at once. `render_scanlines_sse` is the earliest form for 4-size packets.
Docker Version: `base/bundle-v0.2.1`

## Tests
#### SINGLE:
```
With 16 threads enabled:
5 and 5: 9.449
10 and 10: 18.277
50 and 50: 101.517

With no threading enabled:
5 and 5: 3.617
10 and 10: 6.605
50 and 50: 31.634
```

#### SSE:
```
With 16 threads enabled:
5 and 5: 7.607
10 and 10: 16.232
50 and 50: 78.457


With no threading enabled:
5 and 5: 3.134
10 and 10: 5.827
50 and 50: 25.741
```

## Related Issues and Screenshots
I noticed that threading is actually slowing down processing. This wasn't the case when it was originally implemented but it is clearly noticeable now.

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.