### PR TITLE
CA-56 Embreeified BVH Objects

### DIFF
--- a/scene.cc
+++ b/scene.cc
@@ -1,7 +1,10 @@
 #include "scene.h"
 #include <embree4/rtcore.h>
 
-Scene::Scene(RTCDevice device, Camera cam) : cam{cam}, rtc_scene{rtcNewScene(device)} {}
+Scene::Scene(RTCDevice device, Camera cam) : cam{cam}, rtc_scene{rtcNewScene(device)} {
+    rtcSetSceneBuildQuality(rtc_scene, RTC_BUILD_QUALITY_HIGH);
+    rtcSetSceneFlags(rtc_scene, RTC_SCENE_FLAG_DYNAMIC);
+}
 
 Scene::~Scene() {
     rtcReleaseScene(rtc_scene);

--- a/sphere_primitive.h
+++ b/sphere_primitive.h
@@ -19,6 +19,7 @@ class SpherePrimitive : public Primitive {
             spherev[2] = position.z();
             spherev[3] = radius;
         }
+        rtcSetGeometryBuildQuality(geom, RTC_BUILD_QUALITY_HIGH);
         rtcCommitGeometry(geom);
     }
 


### PR DESCRIPTION
# Description
Embree naturally creates data structures, including a BVH network, to optimize the render time and memory usage of scenes. This PR just experiments with which has the lowest render time (does not account for memory) for the current benchmark scene.
Docker Version: `base/bundle-v0.2.1`

## Tests
See https://www.notion.so/CA-56-Embreefied-BVH-objects-4a29b7d9a2a8450cb6b91ca62019fae1?pvs=4

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.