### PR TITLE
CA-100 optimized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 
 # CMake Build Directory
 build/
+.vscode/settings.json

--- a/main.cc
+++ b/main.cc
@@ -168,23 +168,51 @@ struct RayQueue {
     ray r;
 };
 
+void completeRayQueueTask(std::vector<RayQueue>& current, std::vector<color>& temp_buffer,
+                        std::vector<color>& full_buffer, std::vector<RayQueue>& queue,
+                        int mask[], int i, int current_index) {
+    // check if theres even any more to do, if not then break out.
+    // this pixel is done so we can update the full buffer.
+    full_buffer[current_index] += temp_buffer[current_index];
+    if (queue.empty()) {
+        mask[i] = 0; // disable this part of the packet from running
+    } else {
+        // replace finished RayQueue with next
+        RayQueue back = queue.back();
+        queue.pop_back();
+        current[i] = back;
+    }
+}
+
 /**
  * @brief Calculates colours of the given RenderData's buffer according to the assigned lines of pixels.
  * 
- * @note is one of many planned functions supporting SSE, AVX, AVX512 i.e 4/8/16 packet size
+ * @note for SSE 4-RayQueue packets scanline rendering
 */
 void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scene_ptr, RenderData& data, Camera cam) {
     int image_width         = data.image_width;
     int image_height        = data.image_height;
     int samples_per_pixel   = data.samples_per_pixel;
     int max_depth           = data.max_depth;
+
+    std::vector<color> full_buffer(image_width);
+
+    std::vector<RayQueue> queue;
+    queue.reserve(image_width);
+
+    std::vector<color> temp_buffer(image_width);
+    std::vector<RayQueue> current(4); // size = 4 only
+
+    int mask[4] = {-1, -1, -1, -1};
     
     for (int j=start_line; j>=start_line - (lines - 1); --j) {
-        std::vector<color> full_buffer(image_width);
+        std::fill(full_buffer.begin(), full_buffer.end(), color(0, 0, 0));
         for (int s=0; s < samples_per_pixel; s++) {
             std::vector<RayQueue> queue;
             std::vector<color> temp_buffer(image_width);
             std::vector<RayQueue> current(4); // size = 4 only
+            std::fill(temp_buffer.begin(), temp_buffer.end(), color(0, 0, 0));
+            queue.clear();
             for (int i=image_width-1; i>=0; --i) {
                 auto u = (i + random_double()) / (image_width-1);
                 auto v = (j + random_double()) / (image_height-1);
@@ -201,7 +229,7 @@ void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scen
                 current[i] = back;
             }
 
-            int mask[4] = {-1, -1, -1, -1};
+            std::fill(std::begin(mask), std::end(mask), -1);
             while (mask[0] != 0 or mask[1] != 0 or mask[2] != 0 or mask[3] != 0) {
                 std::vector<ray> rays;
                 for (int i=0; i<(int)current.size(); i++) {
@@ -224,46 +252,14 @@ void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scen
                         std::shared_ptr<Geometry> geomhit = scene_ptr->geom_map[rayhit.hit.geomID[i]];
                         std::shared_ptr<material> mat_ptr = geomhit->materialById(rayhit.hit.geomID[i]);
                         record = geomhit->getHitInfo(current_ray, current_ray.at(rayhit.ray.tfar[i]), rayhit.ray.tfar[i], rayhit.hit.geomID[i]);
-                        if (mat_ptr->scatter(current_ray, record, attenuation, scattered)) {
-                            if (current[i].depth == 0) {
-                                temp_buffer[current_index] = attenuation;
-                            } else {
-                                temp_buffer[current_index] = temp_buffer[current_index] * attenuation;
-                            }
-                            if (current[i].depth + 1 == max_depth) { // reached max depth, replace with next in queue
-                                // check if theres even any more to do, if not then break out.
-                                if (queue.empty()) {
-                                    mask[i] = 0; // disable this part of the packet from running
-                                } else {
-                                    // replace finished RayQueue with next
-                                    RayQueue back = queue.back();
-                                    queue.pop_back();
-                                    current[i] = back;
-                                }
-                            } else { // not finished depth wise
-                                current[i].depth += 1;
-                                current[i].r = scattered;
-                            }
-                        } else {
-                            if (current[i].depth == 0) {
-                                temp_buffer[current_index] = color(0,0,0);
-                            } else {
-                                temp_buffer[current_index] = temp_buffer[current_index] * color(0,0,0);
-                            }
-                            if (current[i].depth + 1 == max_depth) { // reached max depth, replace with next in queue
-                                // check if theres even any more to do, if not then break out.
-                                if (queue.empty()) {
-                                    mask[i] = 0; // disable this part of the packet from running
-                                } else {
-                                    // replace finished RayQueue with next
-                                    RayQueue back = queue.back();
-                                    queue.pop_back();
-                                    current[i] = back;
-                                }
-                            } else { // not finished depth wise
-                                current[i].depth += 1;
-                                current[i].r = scattered;
-                            }
+                        if (!mat_ptr->scatter(current_ray, record, attenuation, scattered)) { attenuation = color(0,0,0); }
+                        if (current[i].depth == 0) { temp_buffer[current_index] = attenuation; }
+                        else { temp_buffer[current_index] = temp_buffer[current_index] * attenuation; }
+                        if (current[i].depth + 1 == max_depth) { // reached max depth, replace with next in queue
+                            completeRayQueueTask(current, temp_buffer, full_buffer, queue, mask, i, current_index);
+                        } else { // not finished depth wise
+                            current[i].depth += 1;
+                            current[i].r = scattered;
                         }
                     } else { // no hit
                         // Sky background (gradient blue-white)
@@ -271,25 +267,22 @@ void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scen
                         auto t = 0.5*(unit_direction.y() + 1.0);
 
                         color multiplier = (1.0-t)*color(1.0, 1.0, 1.0) + t*color(0.5, 0.7, 1.0); // lerp formula (1.0-t)*start + t*endval
-                        if (current[i].depth == 0) {
-                            temp_buffer[current_index] = multiplier;
-                        } else {
-                            temp_buffer[current_index] = temp_buffer[current_index] * multiplier;
-                        }
-                        // check if theres even any more to do, if not then break out.
-                        if (queue.empty()) {
-                            mask[i] = 0; // disable this part of the packet from running
-                        } else {
-                            // replace finished RayQueue with next
-                            RayQueue back = queue.back();
-                            queue.pop_back();
-                            current[i] = back;
-                        }
+                        if (current[i].depth == 0) { temp_buffer[current_index] = multiplier; } 
+                        else { temp_buffer[current_index] = temp_buffer[current_index] * multiplier; }
+                        completeRayQueueTask(current, temp_buffer, full_buffer, queue, mask, i, current_index);
                     }
                 }
             }
-            for (int i=0; i<image_width; ++i) {
-                full_buffer[i] += temp_buffer[i];
+        }
+        for (int i=0; i<image_width; ++i) {
+            int buffer_index = j * image_width + i;
+            data.buffer[buffer_index] = color(full_buffer[i].x(), full_buffer[i].y(), full_buffer[i].z());
+        }
+        data.completed_lines += 1;
+        float percentage_completed = ((float)data.completed_lines / (float)data.image_height)*100.00;
+        std::cerr << "[" <<int(percentage_completed) << "%] completed" << std::endl;
+    }
+}
             }
         }
         for (int i=0; i<image_width; ++i) {

--- a/main.cc
+++ b/main.cc
@@ -208,9 +208,6 @@ void render_scanlines_sse(int lines, int start_line, std::shared_ptr<Scene> scen
     for (int j=start_line; j>=start_line - (lines - 1); --j) {
         std::fill(full_buffer.begin(), full_buffer.end(), color(0, 0, 0));
         for (int s=0; s < samples_per_pixel; s++) {
-            std::vector<RayQueue> queue;
-            std::vector<color> temp_buffer(image_width);
-            std::vector<RayQueue> current(4); // size = 4 only
             std::fill(temp_buffer.begin(), temp_buffer.end(), color(0, 0, 0));
             queue.clear();
             for (int i=image_width-1; i>=0; --i) {


### PR DESCRIPTION
See #46 for more details. Added the planned `render_scanlines_avx` function for 8-size packets, shorted and optimized both `render_scanlines_XXX` by making it so that the various buffers and vectors are not reinstantiated and reallocated every loop, but rather once and modified.