### PR TITLE
CA-50 Added Quadrilaterals Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(embree_DIR ../opt/lib/cmake/embree-4.3.0/)
 # set(TBB_DIR ../opt/lib/cmake/tbb/) haven't installed TBB, doesn't exist
 FIND_PACKAGE(embree 4 REQUIRED)
 
-add_executable(caitlyn vec3.cc scene.cc main.cc) # Required
+add_executable(caitlyn vec3.cc scene.cc aabb.cc quad.cc main.cc) # Required
 
 # EMBREE CONFIG
 TARGET_LINK_LIBRARIES(caitlyn embree)

--- a/aabb.cc
+++ b/aabb.cc
@@ -1,0 +1,10 @@
+#include "aabb.h"
+
+aabb::pad() {
+    double delta = 0.0001;
+    interval new_x = (x.size() >= delta) ? x : x.expand(delta);
+    interval new_y = (y.size() >= delta) ? y : y.expand(delta);
+    interval new_z = (z.size() >= delta) ? z : z.expand(delta);
+
+    return aabb(new_x, new_y, new_z);
+}

--- a/aabb.cc
+++ b/aabb.cc
@@ -1,6 +1,6 @@
 #include "aabb.h"
 
-aabb::pad() {
+aabb aabb::pad() {
     double delta = 0.0001;
     interval new_x = (x.size() >= delta) ? x : x.expand(delta);
     interval new_y = (y.size() >= delta) ? y : y.expand(delta);

--- a/aabb.h
+++ b/aabb.h
@@ -52,6 +52,11 @@ public:
 
         return true;
     }
+
+    /**
+     * @return aabb padded to prevent zero thickness
+     */
+    aabb pad();
 };
 
 

--- a/main.cc
+++ b/main.cc
@@ -11,6 +11,7 @@
 #include "hittable_list.h"
 #include "material.h"
 #include "sphere.h"
+#include "quad.h"
 #include "texture.h"
 #include "bvh.h"
 

--- a/main.cc
+++ b/main.cc
@@ -346,11 +346,42 @@ void earth() {
     output(render_data, cam);
 }
 
+void quads() {
+    RenderData render_data; 
+    const auto aspect_ratio = 16.0 / 9.0;
+    setRenderData(render_data, aspect_ratio, 400, 100, 50);
+
+    // Materials
+    auto left_red     = make_shared<lambertian>(color(1.0, 0.2, 0.2));
+    auto back_green   = make_shared<lambertian>(color(0.2, 1.0, 0.2));
+    auto right_blue   = make_shared<lambertian>(color(0.2, 0.2, 1.0));
+    auto upper_orange = make_shared<lambertian>(color(1.0, 0.5, 0.0));
+    auto lower_teal   = make_shared<lambertian>(color(0.2, 0.8, 0.8));
+
+    // Quads
+    render_data.scene.add(make_shared<quad>(point3(-3,-2, 5), vec3(0, 0,-4), vec3(0, 4, 0), left_red));
+    render_data.scene.add(make_shared<quad>(point3(-2,-2, 0), vec3(4, 0, 0), vec3(0, 4, 0), back_green));
+    render_data.scene.add(make_shared<quad>(point3( 3,-2, 1), vec3(0, 0, 4), vec3(0, 4, 0), right_blue));
+    render_data.scene.add(make_shared<quad>(point3(-2, 3, 1), vec3(4, 0, 0), vec3(0, 0, 4), upper_orange));
+    render_data.scene.add(make_shared<quad>(point3(-2,-3, 5), vec3(4, 0, 0), vec3(0, 0,-4), lower_teal));
+
+    // Set up Camera
+    point3 lookfrom(0, 0 , 9);
+    point3 lookat(0,0,0);
+    vec3 vup(0,1,0);
+    double vfov = 80;
+    double aperture = 0.0001;
+    double dist_to_focus = 10.0;
+
+    camera cam(lookfrom, lookat, vup, vfov, aspect_ratio, aperture, dist_to_focus, 0.0, 1.0);
+}
+
 int main() {
     switch (3) {
         case 1:  random_spheres(); break;
         case 2:  two_spheres();    break;
         case 3:  earth();          break;
+        case 4:  quads();          break;
     }
 }
 

--- a/quad.cc
+++ b/quad.cc
@@ -10,11 +10,11 @@ quad::quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material
         this->set_bounding_box();
     }
 
-virtual void quad::set_bounding_box() {
+void quad::set_bounding_box() {
     this->bbox = aabb(Q, Q + u + v).pad();
 }
 
-virtual bool is_interior(double a, double b, hit_record& rec) const {
+bool quad::is_interior(double a, double b, hit_record& rec) const {
     
     if ((a < 0) || (1 < a) || (b < 0) || (1 < b)) return false;
 
@@ -23,7 +23,7 @@ virtual bool is_interior(double a, double b, hit_record& rec) const {
     return true;
 }
 
-bool quad::hit(const ray& r, interval ray_t, hit_record& rec) const override {
+bool quad::hit(const ray& r, interval ray_t, hit_record& rec) const {
     
     // return false (no hit) if ray parallel to plane (dot product ~0)
     float denom = dot(this->normal, r.direction());
@@ -36,7 +36,7 @@ bool quad::hit(const ray& r, interval ray_t, hit_record& rec) const override {
     // return false if hit point lies outside planar shape
     point3 intersection = r.at(t);
     vec3 planar_hitpoint = intersection - this->Q;
-    float alpha = dot(this->w, corss(planar_hitpoint, this->v));
+    float alpha = dot(this->w, cross(planar_hitpoint, this->v));
     float beta = dot(this->w, cross(this->u, planar_hitpoint));
 
     if (!this->is_interior(alpha, beta, rec)) return false;
@@ -44,7 +44,7 @@ bool quad::hit(const ray& r, interval ray_t, hit_record& rec) const override {
     // ray hits 2D shape: set hit record and return true
     rec.t = t;
     rec.p = intersection;
-    rec.mat = this->mat;
+    rec.mat_ptr = this->mat;
     rec.set_face_normal(r, this->normal);
 
     return true;
@@ -56,5 +56,5 @@ vec3 quad::get_u() const { return this->u; }
 vec3 quad::get_v() const { return this->v; }
 vec3 quad::get_w() const { return this->w; }
 vec3 quad::get_normal() const { return this->normal; }
-shared_ptr<material> get_mat() const { return this->mat; }
-aabb quad::bounding_box() const override { return this->bbox; }
+shared_ptr<material> quad::get_mat() const { return this->mat; }
+aabb quad::bounding_box() const { return this->bbox; }

--- a/quad.cc
+++ b/quad.cc
@@ -1,0 +1,20 @@
+#include "quad.h"
+
+quad::quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> _mat) :
+    Q(_Q), u(_u), v(_v), mat(_mat) {
+        this->set_bounding_box();
+    }
+
+virtual void quad::set_bounding_box() {
+    this->bbox = aabb(Q, Q + u + v).pad();
+}
+
+point3 get_Q() const { return this->Q; }
+vec3 get_u() const { return this->u; }
+vec3 get_u() const { return this->v; }
+shared_ptr<material> get_mat() const { return this->mat; }
+aabb quad::bounding_box() const override { return this->bbox; }
+
+bool quad::hit(const ray& r, interval ray_t, hit_record& rec) const override {
+    return false; // To be implemented
+}

--- a/quad.cc
+++ b/quad.cc
@@ -2,6 +2,11 @@
 
 quad::quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> _mat) :
     Q(_Q), u(_u), v(_v), mat(_mat) {
+        auto n = cross(u, v);
+        this->normal = n.unit_vector();
+        this->D = dot(normal, Q);
+        this->w = n / dot(n, n);
+
         this->set_bounding_box();
     }
 
@@ -9,12 +14,31 @@ virtual void quad::set_bounding_box() {
     this->bbox = aabb(Q, Q + u + v).pad();
 }
 
-point3 get_Q() const { return this->Q; }
-vec3 get_u() const { return this->u; }
-vec3 get_u() const { return this->v; }
+double quad::get_D() const { return this->D; }
+point3 quad::get_Q() const { return this->Q; }
+vec3 quad::get_u() const { return this->u; }
+vec3 quad::get_v() const { return this->v; }
+vec3 quad::get_w() const { return this->w; }
+vec3 quad::get_normal() const { return this->normal; }
 shared_ptr<material> get_mat() const { return this->mat; }
 aabb quad::bounding_box() const override { return this->bbox; }
 
 bool quad::hit(const ray& r, interval ray_t, hit_record& rec) const override {
-    return false; // To be implemented
+    
+    // return false (no hit) if ray parallel to plane (dot product ~0)
+    float denom = dot(this->normal, r.direction());
+    if (fabs(denom) < 1e-8) return false;
+
+    // return false if hit point (t) outside interval (ray_t)
+    double t = (this->D - dot(normal, r.origin())) / denom;
+    if (!ray_t.contains(t)) return false;
+
+    point3 intersection = r.at(t);
+
+    rec.t = t;
+    rec.p = intersection;
+    rec.mat = this->mat;
+    rec.set_face_normal(r, this->normal);
+
+    return true;
 }

--- a/quad.h
+++ b/quad.h
@@ -12,6 +12,9 @@ class quad : public hittable {
         vec3 u, v;
         shared_ptr<material> mat;
         aabb bbox;
+        vec3 normal;
+        vec3 w;
+        double D;
 
     public:
 
@@ -21,9 +24,13 @@ class quad : public hittable {
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
+        // getter functions
+        double get_D() const;
         point3 get_Q() const;
         vec3 get_u() const;
         vec3 get_v() const;
+        vec3 get_w() const;
+        vec3 get_normal() const;
         shared_ptr<material> get_mat() const;
         aabb bounding_box() const override;
 

--- a/quad.h
+++ b/quad.h
@@ -1,0 +1,32 @@
+#ifndef QUAD_H
+#define QUAD_H
+
+#include "general.h"
+#include "hittable.h"
+
+class quad : public hittable {
+    
+    private:
+
+        point3 Q;
+        vec3 u, v;
+        shared_ptr<material> mat;
+        aabb bbox;
+
+    public:
+
+        quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> _mat);
+
+        virtual void set_bounding_box();
+
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+
+        point3 get_Q() const;
+        vec3 get_u() const;
+        vec3 get_v() const;
+        shared_ptr<material> get_mat() const;
+        aabb bounding_box() const override;
+
+};
+
+#endif

--- a/quad.h
+++ b/quad.h
@@ -1,6 +1,8 @@
 #ifndef QUAD_H
 #define QUAD_H
 
+#include <cmath>
+
 #include "general.h"
 #include "hittable.h"
 
@@ -21,6 +23,16 @@ class quad : public hittable {
         quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> _mat);
 
         virtual void set_bounding_box();
+        
+        /**
+         * @brief checks if hit point in quad and set rec UV coordinates if it is
+         * 
+         * @param[in]   a, b    the hit point in plane coordinates 
+         * @param[out]  rec     the hit record
+         * 
+         * @return if the hit point is in the primitive
+         */
+        virtual bool is_interior(double a, double b, hit_record& rec) const;
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 


### PR DESCRIPTION
# Description
Added support for Quadrilaterals (2D objects in 3D plane)
This change encompasses Section 6 of The Next Week.
It will also be the foundation for general polygons and 3D meshes in the future.
Docker Version: base/bundle-v0.2.1

# Tests
CPU: Intel i7-9750H at 4.0GHz overclocked
Quad: 318.735 seconds - 100 samples per pixel, 50 max-depth

# Related Issues and Screenshots
![image](https://github.com/cypraeno/caitlyn/assets/117124009/e3c19093-bdee-416f-9a07-520dd3f404e2)

# Checklist
- [x]  I have added clean documentation to my code where necessary.
- [x]  I have tested the new code and have done so in Docker
- [x]  I have fixed merged branch with current.
- [x]  I have fixed any merge conflicts and have tested the changes.