### PR TITLE
CA-81 Load scene file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csr eol=lf

--- a/CSRParser.h
+++ b/CSRParser.h
@@ -15,10 +15,21 @@
 #include "quad_primitive.h"
 #include "scene.h"
 
+/**
+ * @class CSRParser
+ * @brief A parser that constructs Scene objects by reading a given CSR (Caitlyn Scene Representation) file.
+ *
+ * Call parseCSR(parseCSR(const std::string& filePath, RTCDevice device) to get a std::shared_ptr<Scene>
+ * parseCSR does NOT validate the formatting and structure of the CSR file, and may result in a seg fault.
+*/
 class CSRParser {
 public:
     std::ifstream file;
 
+    /**
+     * @brief Parses a CSR file and returns a std::shared_ptr<Scene> WITHOUT the scene committed.
+     * The user must call scene_ptr->commitScene(); and rtcReleaseDevice(device);.
+    */
     std::shared_ptr<Scene> parseCSR(const std::string& filePath, RTCDevice device) {
         file = std::ifstream(filePath);
         std::string line;

--- a/csr_parser.h
+++ b/csr_parser.h
@@ -1,0 +1,131 @@
+#ifndef CSRPARSER_H
+#define CSRPARSER_H
+
+#include <embree4/rtcore.h>
+#include <memory>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <optional>
+#include "camera.h"
+#include "material.h"
+#include "sphere_primitive.h"
+#include "scene.h"
+
+class CSRParser {
+public:
+    std::ifstream file;
+
+    std::shared_ptr<Scene> parseCSR(const std::string& filePath, RTCDevice device) {
+        file = std::ifstream(filePath);
+        std::string line;
+        std::map<std::string, std::shared_ptr<material>> materials;
+        
+        if (!file.is_open()) {
+            throw std::runtime_error("Could not open file: " + filePath);
+        }
+
+        // Read in versionn
+        getline(file, line);
+        if (trim(line) != "version 0.1.0") {
+            throw std::runtime_error("Unsupported version or missing version marker");
+        }
+
+        Camera cam = readCamera();
+        auto scene_ptr = make_shared<Scene>(device, cam);
+
+        while (getline(file, line)) {
+            line = trim(line);
+            if (startsWith(line, "Material")) {
+                // Extract material ID from brackets (e.g., Material[Lambertian] -> Lambertian)
+                auto idStart = line.find('[') + 1;
+                auto idEnd = line.find(']');
+                std::string materialType = line.substr(idStart, idEnd - idStart);
+                if (materialType == "Lambertian") {
+                    std::string materialId, texture, albedo;
+                    getline(file, materialId); getline(file, texture); getline(file, albedo);
+                    if (readStringProperty(texture) == "no") {
+                        materials[readStringProperty(materialId)] = std::make_shared<lambertian>(readXYZProperty(albedo));  
+                    }  
+                }
+            } else if (startsWith(line, "Sphere")) {
+                std::string position, material, radius;
+                getline(file, position); getline(file, material); getline(file, radius);
+                auto sphere = make_shared<SpherePrimitive>(readXYZProperty(position), materials[readStringProperty(material)], readDoubleProperty(radius), device);
+                scene_ptr->add_primitive(sphere);
+            }
+        }
+
+        return scene_ptr;
+    }
+private:
+    // Helper String Functions
+    std::vector<std::string> split(const std::string &s, char delimiter = ' ') {
+        std::vector<std::string> tokens;
+        std::istringstream tokenStream(s);
+        std::string token;
+        while (std::getline(tokenStream, token, delimiter)) {
+            tokens.push_back(token);
+        }
+        return tokens;
+    }
+
+    std::string trim(const std::string& str) {
+        size_t first = str.find_first_not_of(' ');
+        if (std::string::npos == first) {
+            return str;
+        }
+        size_t last = str.find_last_not_of(' ');
+        return str.substr(first, (last - first + 1));
+    }
+
+    bool startsWith(const std::string& str, const std::string& prefix) {
+        return str.size() >= prefix.size() &&
+            str.compare(0, prefix.size(), prefix) == 0;
+    }
+
+    point3 readXYZProperty(std::string line) {
+        auto tokens = split(line);
+        point3 p(std::stof(tokens[1]), std::stof(tokens[2]), std::stof(tokens[3]));
+        return p;
+    }
+
+    double readDoubleProperty(std::string line) {
+        auto tokens = split(line);
+        return std::stod(tokens[1]);
+    }
+
+    std::string readStringProperty(std::string line) {
+        auto tokens = split(line);
+        return tokens[1];
+    }
+
+    double readRatioProperty(std::string line) {
+        auto tokens = split(line);
+        auto ratio_tokens = split(tokens[1], '/');
+        return std::stod(ratio_tokens[0]) / std::stod(ratio_tokens[1]);
+    }
+
+    // Reading in objects
+    Camera readCamera() {
+        std::string line;
+        std::string lookfrom, lookat, vup, vfov, aspect_ratio, aperture, focus_dist;
+        while (getline(file, line)) {
+            if (startsWith(line, "Camera")) {
+                getline(file, lookfrom); getline(file, lookat); getline(file, vup);
+                getline(file, vfov); getline(file, aspect_ratio); getline(file, aperture); getline(file, focus_dist);
+                break;
+            }
+        }
+        Camera cam(readXYZProperty(lookfrom), readXYZProperty(lookat),
+            readXYZProperty(vup), readDoubleProperty(vfov),
+            readRatioProperty(aspect_ratio), readDoubleProperty(aperture),
+            readDoubleProperty(focus_dist));
+        return cam;
+    }
+
+    
+};
+
+#endif

--- a/csr_parser.h
+++ b/csr_parser.h
@@ -49,6 +49,14 @@ public:
                     if (readStringProperty(texture) == "no") {
                         materials[readStringProperty(materialId)] = std::make_shared<lambertian>(readXYZProperty(albedo));  
                     }  
+                } else if (materialType == "Metal") {
+                    std::string materialId, albedo, fuzz;
+                    getline(file, materialId); getline(file, albedo); getline(file, fuzz);
+                    materials[readStringProperty(materialId)] = std::make_shared<metal>(readXYZProperty(albedo), readDoubleProperty(fuzz));
+                } else if (materialType == "Dielectric") {
+                    std::string materialId, ir;
+                    getline(file, materialId); getline(file, ir);
+                    materials[readStringProperty(materialId)] = std::make_shared<dielectric>(readDoubleProperty(ir));
                 }
             } else if (startsWith(line, "Sphere")) {
                 std::string position, material, radius;

--- a/csr_parser.h
+++ b/csr_parser.h
@@ -11,6 +11,7 @@
 #include "camera.h"
 #include "material.h"
 #include "sphere_primitive.h"
+#include "quad_primitive.h"
 #include "scene.h"
 
 class CSRParser {
@@ -54,6 +55,11 @@ public:
                 getline(file, position); getline(file, material); getline(file, radius);
                 auto sphere = make_shared<SpherePrimitive>(readXYZProperty(position), materials[readStringProperty(material)], readDoubleProperty(radius), device);
                 scene_ptr->add_primitive(sphere);
+            } else if (startsWith(line, "Quad")) {
+                std::string position, u, v, material;
+                getline(file, position); getline(file, u); getline(file, v); getline(file, material);
+                auto quad = make_shared<QuadPrimitive>(readXYZProperty(position), readXYZProperty(u), readXYZProperty(v), materials[readStringProperty(material)], device);
+                scene_ptr->add_primitive(quad);
             }
         }
 
@@ -71,12 +77,15 @@ private:
         return tokens;
     }
 
+
     std::string trim(const std::string& str) {
-        size_t first = str.find_first_not_of(' ');
+        // Include '\r' and '\n' in the character set for trimming
+        size_t first = str.find_first_not_of(" \r\n");
         if (std::string::npos == first) {
-            return str;
+            // Return an empty string if only whitespace characters are found
+            return "";
         }
-        size_t last = str.find_last_not_of(' ');
+        size_t last = str.find_last_not_of(" \r\n");
         return str.substr(first, (last - first + 1));
     }
 

--- a/main.cc
+++ b/main.cc
@@ -551,7 +551,6 @@ void earth() {
     output(render_data, cam, scene_ptr);
 }
 
-<<<<<<< HEAD
 /**
  * @brief loads "example.csr" in the same directory.
  * @note ONLY SUPPORTS LAMBERTIAN SOLID COLOURS, AND SPHERES.
@@ -569,7 +568,8 @@ void load_example() {
     rtcReleaseDevice(device);
 
     output(render_data, scene_ptr->cam, scene_ptr);
-=======
+}
+
 void quads() {
     RenderData render_data; 
     const auto aspect_ratio = 16.0 / 9.0;
@@ -614,19 +614,15 @@ void quads() {
     rtcReleaseDevice(device);
 
     output(render_data, cam, scene_ptr);
->>>>>>> CA-102-embree-week
 }
 
 int main() {
-    switch (4) {
+    switch (5) {
         case 1:  random_spheres(); break;
         case 2:  two_spheres();    break;
         case 3:  earth();          break;
-<<<<<<< HEAD
-        case 4:  load_example();   break;
-=======
         case 4:  quads();          break;
->>>>>>> CA-102-embree-week
+        case 5:  load_example();   break;
     }
 }
 

--- a/main.cc
+++ b/main.cc
@@ -553,13 +553,12 @@ void earth() {
 
 /**
  * @brief loads "example.csr" in the same directory.
- * @note Does not support textured lambertians
  * @note see example.csr in cypraeno/csr_schema repository
 */
 void load_example() {
     RenderData render_data;
     const auto aspect_ratio = 16.0 / 9.0;
-    setRenderData(render_data, aspect_ratio, 1200, 50, 50);
+    setRenderData(render_data, aspect_ratio, 400, 50, 50);
     std::string filePath = "example.csr";
     RTCDevice device = initializeDevice();
     CSRParser parser;

--- a/main.cc
+++ b/main.cc
@@ -553,13 +553,13 @@ void earth() {
 
 /**
  * @brief loads "example.csr" in the same directory.
- * @note ONLY SUPPORTS LAMBERTIAN SOLID COLOURS, AND SPHERES.
+ * @note Does not support textured lambertians
  * @note see example.csr in cypraeno/csr_schema repository
 */
 void load_example() {
     RenderData render_data;
     const auto aspect_ratio = 16.0 / 9.0;
-    setRenderData(render_data, aspect_ratio, 400, 50, 50);
+    setRenderData(render_data, aspect_ratio, 1200, 50, 50);
     std::string filePath = "example.csr";
     RTCDevice device = initializeDevice();
     CSRParser parser;

--- a/main.cc
+++ b/main.cc
@@ -1,5 +1,5 @@
 #include <embree4/rtcore.h>
-#include "csr_parser.h"
+#include "CSRParser.h"
 #include "device.h"
 #include "general.h"
 #include "scene.h"

--- a/main.cc
+++ b/main.cc
@@ -1,4 +1,5 @@
 #include <embree4/rtcore.h>
+#include "csr_parser.h"
 #include "device.h"
 #include "general.h"
 #include "scene.h"
@@ -549,11 +550,31 @@ void earth() {
     output(render_data, cam, scene_ptr);
 }
 
+/**
+ * @brief loads "example.csr" in the same directory.
+ * @note ONLY SUPPORTS LAMBERTIAN SOLID COLOURS, AND SPHERES.
+ * @note see example.csr in cypraeno/csr_schema repository
+*/
+void load_example() {
+    RenderData render_data;
+    const auto aspect_ratio = 16.0 / 9.0;
+    setRenderData(render_data, aspect_ratio, 400, 50, 50);
+    std::string filePath = "example.csr";
+    RTCDevice device = initializeDevice();
+    CSRParser parser;
+    auto scene_ptr = parser.parseCSR(filePath, device);
+    scene_ptr->commitScene();
+    rtcReleaseDevice(device);
+
+    output(render_data, scene_ptr->cam, scene_ptr);
+}
+
 int main() {
-    switch (1) {
+    switch (4) {
         case 1:  random_spheres(); break;
         case 2:  two_spheres();    break;
         case 3:  earth();          break;
+        case 4:  load_example();   break;
     }
 }
 

--- a/sphere_primitive.h
+++ b/sphere_primitive.h
@@ -36,7 +36,7 @@ class SpherePrimitive : public Primitive {
         record.set_face_normal(r, outward_normal);
 
         double u, v;
-        get_sphere_uv(p, u, v);
+        get_sphere_uv(outward_normal, u, v);
         record.u = u;
         record.v = v;
 


### PR DESCRIPTION
# Description
With a CSRParser class, adds ability to read in CSR files (assuming proper formatting) and construct Scene objects. The `load_example()` function is another option alongside quads, two_spheres, etc. that loads in `example.csr` and renders.
Docker Version: `base/bundle-v0.2.1`

## Tests
Tested with a variety of CSR files, including but not limited to the most current example.csr: 
https://github.com/cypraeno/csr-schema/blob/main/example.csr


## Related Issues and Screenshots
![image](https://github.com/cypraeno/caitlyn/assets/25397938/f8bb1041-e00b-4a92-8476-e6c06ab33832)

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.