### PR TITLE
CA-109 Meshes in CSR and CLI

### DIFF
--- a/include/CLIParser.h
+++ b/include/CLIParser.h
@@ -118,7 +118,8 @@ Config parseArguments(int argc, char* argv[]) {
             }
         } else if(arg == "-v" || arg == "--version") {
             config.showVersion = true;
-            std::cout << "caitlyn version 0.1.2" << std::endl;
+            std::cout << "caitlyn version 0.1.3" << std::endl;
+            exit(0);
         } else if(arg == "-h" || arg == "--help") {
             config.showHelp = true;
             outputHelpGuide(std::cout);

--- a/include/CSRParser.h
+++ b/include/CSRParser.h
@@ -14,6 +14,7 @@
 #include "texture.h"
 #include "sphere_primitive.h"
 #include "quad_primitive.h"
+#include "mesh.h"
 #include "scene.h"
 
 /**
@@ -44,7 +45,7 @@ public:
 
         // Read in version
         getNextLine(file, line);
-        if (trim(line) != "version 0.1.2") {
+        if (trim(line) != "version 0.1.3") {
             rtcReleaseDevice(device);
             throw std::runtime_error("Unsupported version or missing version marker");
         }
@@ -116,6 +117,12 @@ public:
                 getNextLine(file, position); getNextLine(file, u); getNextLine(file, v); getNextLine(file, material);
                 auto quad = make_shared<QuadPrimitive>(readXYZProperty(position), readXYZProperty(u), readXYZProperty(v), materials[readStringProperty(material)], device);
                 scene_ptr->add_primitive(quad);
+            } else if (startsWith(line, "Mesh")) {
+                std::string position, path, scale;
+                getNextLine(file, position); getNextLine(file, path); getNextLine(file, scale);
+                std::string path_str = readStringProperty(path);
+                auto mesh = make_shared<Mesh>(readXYZProperty(position), readDoubleProperty(scale), path_str, device);
+                scene_ptr->add_mesh(mesh);
             }
         }
 

--- a/main.cc
+++ b/main.cc
@@ -944,7 +944,7 @@ void mesh_example() {
     scene_ptr->add_mesh(tree);
 
     std::string grassPath = "grass.obj";
-    auto grass1 = make_shared<Mesh>(point3(-2,-0.6,-1), 4, grassPath, device);
+    auto grass1 = make_shared<Mesh>(point3(-2,-0.6,-1), 3.5, grassPath, device);
     scene_ptr->add_mesh(grass1);
     auto grass2 = make_shared<Mesh>(point3(0,-0.6,1.5), 3.5, grassPath, device);
     scene_ptr->add_mesh(grass2);
@@ -981,7 +981,7 @@ void mesh_example() {
 
 int main(int argc, char* argv[]) {
     Config config = parseArguments(argc, argv);
-    switch (9) {
+    switch (5) {
         case 1:  random_spheres(); break;
         case 2:  two_spheres();    break;
         case 3:  earth();          break;


### PR DESCRIPTION
# Description
Updates to verson v0.1.3. Now can take in Mesh in CSR files with the following format:
```
Mesh
position x y z
path /path/to/name.obj
scale double
```
Docker Version: `base/bundle-v0.2.1`

## Tests
Tested on [grass_horse.csr](https://github.com/cypraeno/csr-schema/tree/main/examples/grass_horse).

## Related Issues and Screenshots
![image](https://github.com/cypraeno/caitlyn/assets/25397938/f96e6d71-2f25-4167-9f56-2d032d1b5a0f)

## Checklist
- [X] I have added clean documentation to my code where necessary.
- [X] I have tested the new code and have done so in Docker
- [X] I have fixed merged branch with current. 
- [X] I have fixed any merge conflicts and have tested the changes.